### PR TITLE
[WIP] composition over propertys

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,19 +49,16 @@ You should then run `flutter packages get` in your terminal so as to get the pac
 
   ```dart
   Final page = new PageViewModel(
-        pageColor: const Color(0xFF607D8B),
-        mainImageAssetPath: 'assets/taxi.png',
-        title: 'Cabs',
-        body: 'Easy cab booking at your doorstep with cashless payment system',
-        iconImageAssetPath: 'assets/taxi-driver.png',
-        titleTextColor: Colors.white,
-        bodyTextColor: Colors.white,
-        iconColor: null,
-        titleTextSize: 54.0,
-        bodyTextSize: 24.0,
-        fontFamily: "MyFont",
-        pageTitleBold: false,
-        bubbleBackgroundColor: Colors.white,
+      pageColor: const Color(0xFF607D8B),
+      title: Text('Cabs'),
+      mainImage: Image.asset('assets/taxi.png'),
+      body: Text(
+        'Easy  cab  booking  at  your  doorstep  with  cashless  payment  system',
+      ),
+      textStyle: TextStyle(fontFamily: 'MyFont'),
+      iconImageAssetPath: 'assets/taxi-driver.png',
+      bubbleBackgroundColor: Colors.white,
+      iconColor: null,
       );
   ```
 
@@ -92,18 +89,13 @@ You should then run `flutter packages get` in your terminal so as to get the pac
 | Dart attribute  | Datatype         | Description                                                  | Default Value |
 | :---------------- | :------------------------------ | :----------------------------------------------------------- | :-----------: |
 | pageColor | Color | Set color of the page. | Null      |
-| mainImageAssetPath | String | Set the main image asset path of the page. | Null      |
-| title | String | Set the title text of the page. | Null      |
-| body | String | Set the body text of the page. | Null       |
+| mainImage | Image | Set the main image of the page. | Null      |
+| title | Text | Set the title text of the page. | Null      |
+| body | Text | Set the body text of the page. | Null       |
 | iconImageAssetPath | String | Set the icon image asset path that would be displayed in page bubble. | Null    |
-| titleTextColor | Color | Set the title text color. | Colors.white |
-| bodyTextColor | Color | Set the body text color. | Colors.white |
 | iconColor | Color | Set the page bubble icon color. | Null |
 | bubbleBackgroundColor | Color | Set the page bubble background color. | Colors.white |
-| fontFamily | String | Use your own custom font to style the title and body. | Default |
-| pageTitleBold | Bool | Set the title font weight to bold. | False |
-| titleTextSize | Double | Set the size of title text. | 34.0 |
-| bodyTextSize | Double | Set the size of body text. | 18.0 |
+| textStyle | TextStyle | set TextStyle for both title and body | title: `color: Colors.white , fontSize: 50.0` <br> body: `color: Colors.white , fontSize: 24.0` |
 
 ### IntroViewFlutter Class
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -11,52 +11,44 @@ class App extends StatelessWidget {
   //making list of pages needed to pass in IntroViewsFlutter constructor.
   final pages = [
     new PageViewModel(
-      pageColor: const Color(0xFF03A9F4),
-      mainImageAssetPath: 'assets/airplane.png',
-      title: 'Flights',
-      body:
+        pageColor: const Color(0xFF03A9F4),
+        iconImageAssetPath: 'assets/air-hostess.png',
+        iconColor: null,
+        bubbleBackgroundColor: Colors.blue[900],
+        body: Text(
           'Haselfree  booking  of  flight  tickets  with  full  refund  on  cancelation',
-      iconImageAssetPath: 'assets/air-hostess.png',
-      titleTextColor: Colors.white,
-      bodyTextColor: Colors.white,
-      fontFamily: "MyFont",
-      titleTextSize: 50.0,
-      bodyTextSize: 24.0,
-      iconColor: null,
-      pageTitleBold: false,
-      bubbleBackgroundColor: Colors.white,
-    ),
+        ),
+        title: Text(
+          'Flights',
+          style: TextStyle(color: Colors.white70),
+        ),
+        textStyle: TextStyle(fontFamily: 'MyFont'),
+        mainImage: Image.asset(
+          'assets/airplane.png',
+        )),
     new PageViewModel(
       pageColor: const Color(0xFF8BC34A),
-      mainImageAssetPath: 'assets/hotel.png',
-      title: 'Hotels',
-      body:
-          'We  work  for  the  comfort ,  enjoy  your  stay  at  our  beautiful  hotels',
       iconImageAssetPath: 'assets/waiter.png',
-      titleTextColor: Colors.white,
-      bodyTextColor: Colors.white,
       iconColor: null,
-      titleTextSize: 54.0,
-      bodyTextSize: 24.0,
-      fontFamily: "MyFont",
-      pageTitleBold: false,
-      bubbleBackgroundColor: Colors.white,
+      bubbleBackgroundColor: Colors.green[900],
+      body: Text(
+        'We  work  for  the  comfort ,  enjoy  your  stay  at  our  beautiful  hotels',
+      ),
+      title: Text('Hotels'),
+      mainImage: Image.asset('assets/hotel.png'),
+      textStyle: TextStyle(fontFamily: 'MyFont'),
     ),
     new PageViewModel(
       pageColor: const Color(0xFF607D8B),
-      mainImageAssetPath: 'assets/taxi.png',
-      title: 'Cabs',
-      body:
-          'Easy  cab  booking  at  your  doorstep  with  cashless  payment  system',
       iconImageAssetPath: 'assets/taxi-driver.png',
-      titleTextColor: Colors.white,
-      bodyTextColor: Colors.white,
       iconColor: null,
-      titleTextSize: 54.0,
-      bodyTextSize: 24.0,
-      fontFamily: "MyFont",
-      pageTitleBold: false,
       bubbleBackgroundColor: Colors.white,
+      body: Text(
+        'Easy  cab  booking  at  your  doorstep  with  cashless  payment  system',
+      ),
+      title: Text('Cabs'),
+      mainImage: Image.asset('assets/taxi.png'),
+      textStyle: TextStyle(fontFamily: 'MyFont'),
     ),
   ];
 

--- a/lib/Models/page_view_model.dart
+++ b/lib/Models/page_view_model.dart
@@ -3,34 +3,53 @@ import 'package:flutter/material.dart';
 //view model for pages
 
 class PageViewModel {
+  /// Page BackGround Color
   final Color pageColor;
-  //main image path
-  final String mainImageAssetPath;
-  final String title;
-  final String body;
-  final String iconImageAssetPath;
-  final Color titleTextColor;
-  final Color bodyTextColor;
-  final Color iconColor;
-  final Color bubbleBackgroundColor;
-  final String fontFamily;
-  final bool pageTitleBold;
-  final double titleTextSize;
-  final double bodyTextSize;
 
-  PageViewModel({
-    this.pageColor,
-    this.mainImageAssetPath,
-    this.title,
-    this.body,
-    this.iconImageAssetPath,
-    this.bodyTextColor = const Color(0x88FFFFFF),
-    this.titleTextColor = const Color(0x88FFFFFF),
-    this.bubbleBackgroundColor = const Color(0x88FFFFFF),
-    this.iconColor,
-    this.fontFamily,
-    this.pageTitleBold = false,
-    this.titleTextSize = 34.0,
-    this.bodyTextSize = 18.0,
-  });
+  ///icon image path
+  final String iconImageAssetPath;
+
+  /// iconColor
+  final Color iconColor;
+
+  /// color for background of progress bubbles
+  /// 
+  /// @Default `const Color(0x88FFFFFF)`
+  final Color bubbleBackgroundColor;
+
+  /// Text widget for the title
+  /// 
+  /// @Default style `color: Colors.white , fontSize: 50.0`
+  final Text title;
+
+  /// Text widget for the title
+  /// 
+  /// @Default style `color: Colors.white, fontSize: 24.0`
+  final Text body;
+
+  /// set default TextStyle for both title and body
+  final TextStyle textStyle;
+
+  /// Image Widget
+  final Image mainImage;
+
+  PageViewModel(
+      {this.pageColor,
+      this.iconImageAssetPath,
+      this.bubbleBackgroundColor = const Color(0x88FFFFFF),
+      this.iconColor,
+      @required this.title,
+      @required this.body,
+      @required this.mainImage,
+      this.textStyle});
+
+  TextStyle get titleTextStyle {
+    return new TextStyle(color: Colors.white, fontSize: 50.0)
+        .merge(this.textStyle);
+  }
+
+  TextStyle get bodyTextStyle {
+    return new TextStyle(color: Colors.white, fontSize: 24.0)
+        .merge(this.textStyle);
+  }
 }

--- a/lib/UI/page.dart
+++ b/lib/UI/page.dart
@@ -100,15 +100,10 @@ class _BodyPageTransform extends StatelessWidget {
           new Matrix4.translationValues(0.0, 30.0 * (1 - percentVisible), 0.0),
       child: new Padding(
         padding: const EdgeInsets.only(bottom: 75.0, left: 10.0, right: 10.0),
-        child: new Text(
-          pageViewModel.body,
-          textAlign: TextAlign.center,
-          style: new TextStyle(
-            color: pageViewModel.bodyTextColor,
-            fontSize: pageViewModel.bodyTextSize,
-            fontFamily: pageViewModel.fontFamily,
-          ), //TextStyle
-        ), //Text
+        child: DefaultTextStyle.merge(
+            style: pageViewModel.bodyTextStyle,
+            textAlign: TextAlign.center,
+            child: pageViewModel.body),
       ), //Padding
     );
   }
@@ -129,22 +124,13 @@ class _ImagePageTransform extends StatelessWidget {
   Widget build(BuildContext context) {
     return new Transform(
       //Used for vertical transformation
-      transform:
-          new Matrix4.translationValues(0.0, 50.0 * (1 - percentVisible), 0.0),
-      child: new Padding(
+      transform: new Matrix4.translationValues(
+          0.0, 50.0 * (1 - percentVisible), 0.0),
+      child: new Container(
+          width: 285.0,
+          height: 285.0,
           padding: new EdgeInsets.only(bottom: 30.0),
-          child: (pageViewModel.mainImageAssetPath != null &&
-                  pageViewModel.mainImageAssetPath != "")
-              ? new Image.asset(
-                  pageViewModel.mainImageAssetPath,
-                  width: 285.0,
-                  height: 285.0,
-                  alignment: Alignment.center,
-                )
-              : new Container(
-                  height: 285.0,
-                  width: 285.0,
-                ) //Loading main icon
+          child: pageViewModel.mainImage, //Loading main 
           ), //Padding
     );
   }
@@ -171,21 +157,10 @@ class _TitlePageTransform extends StatelessWidget {
       child: new Padding(
         padding: new EdgeInsets.only(
             top: 60.0, bottom: 30.0, left: 10.0, right: 10.0),
-        child: new Text(
-          pageViewModel.title,
-          style: (pageViewModel.pageTitleBold)
-              ? new TextStyle(
-                  color: pageViewModel.titleTextColor,
-                  fontFamily: pageViewModel.fontFamily,
-                  fontWeight: FontWeight.bold,
-                  fontSize: pageViewModel.titleTextSize,
-                )
-              : new TextStyle(
-                  color: pageViewModel.titleTextColor,
-                  fontFamily: pageViewModel.fontFamily,
-                  fontSize: pageViewModel.titleTextSize,
-                ), //TextStyle
-        ), //Text
+        child: DefaultTextStyle.merge(
+          style: pageViewModel.titleTextStyle,
+          child: pageViewModel.title,
+        ),
       ), //Padding
     );
   }

--- a/lib/UI/page_bubble.dart
+++ b/lib/UI/page_bubble.dart
@@ -34,7 +34,7 @@ class PageBubble extends StatelessWidget {
               color: viewModel.isHollow
                   ? viewModel.bubbleBackgroundColor
                       .withAlpha((0x88 * viewModel.activePercent).round())
-                  : const Color(0x88FFFFFF),
+                  : viewModel.bubbleBackgroundColor.withOpacity(lerpDouble(0.5, 1.0, viewModel.activePercent)),
               border: new Border.all(
                 color: viewModel.isHollow
                     ? viewModel.bubbleBackgroundColor.withAlpha(


### PR DESCRIPTION
# Breaking Changes ahead.
#### major or minor version number should be changed. 

 refactor of **PageViewModel** so that we could pass image, custom body, title Text Widgets with their indevidual TextStyles.
there is also a new `textStyle` property on `PageViewModel` to give shared Text style to both tittle and body.

i also want to expose the Text widget's of the skip / done,
and convert `iconImageAssetPath` to expose its Widget, to be able to use either an Icon or Image. 
with that consolidate  `iconImageAssetPath` `iconColor` into a single widget property

tell me what you think.


Breaking Change's - PageViewModel - title, body, mainImage expect Widgets
 - removed unneeded properies

+body title, expect Text Widget.

+mainImage expects Image Widget.

+add textStyle property to PageViewModel that can be used to set styles for
both title and body.

+give title, body default styles.

