### PR TITLE
background: Color.transparent

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ You should then run `flutter packages get` in your terminal so as to get the pac
 | doneButtonPersist       | Bool                | Show done Button throughout pages                                                                                 |                  false                  |
 | columnMainAxisAlignment | MainAxisAlignment   | Control [MainAxisAlignment] for column                                                                            |      MainAxisAlignment.spaceAround      |
 | fullTransition          | double              | Adjust scroll distance for full transition                                                                        |                  300.0                  |
+| background              | Color               | Set the background color to Colors.transparent if you have your own background image below | null |
 
 For help on editing package code, view the [flutter documentation](https://flutter.io/developing-packages/).
 

--- a/lib/intro_views_flutter.dart
+++ b/lib/intro_views_flutter.dart
@@ -234,7 +234,7 @@ class _IntroViewsFlutterState extends State<IntroViewsFlutter>
     return Scaffold(
       //Stack is used to place components over one another.
       resizeToAvoidBottomPadding: false,
-      color: this.background,
+      backgroundColor: widget.background,
       body: Stack(
         children: <Widget>[
           Page(

--- a/lib/intro_views_flutter.dart
+++ b/lib/intro_views_flutter.dart
@@ -115,7 +115,7 @@ class IntroViewsFlutter extends StatefulWidget {
     this.doneButtonPersist = false,
     this.columnMainAxisAlignment = MainAxisAlignment.spaceAround,
     this.fullTransition = FULL_TARNSITION_PX,
-    this.background = null,
+    this.background,
   }) : super(key: key);
 
   @override

--- a/lib/intro_views_flutter.dart
+++ b/lib/intro_views_flutter.dart
@@ -91,6 +91,8 @@ class IntroViewsFlutter extends StatefulWidget {
   ///
   /// default to 300.0
   final double fullTransition;
+  
+  final Color background;
 
   IntroViewsFlutter(
     this.pages, {
@@ -113,6 +115,7 @@ class IntroViewsFlutter extends StatefulWidget {
     this.doneButtonPersist = false,
     this.columnMainAxisAlignment = MainAxisAlignment.spaceAround,
     this.fullTransition = FULL_TARNSITION_PX,
+    this.background = null,
   }) : super(key: key);
 
   @override
@@ -231,6 +234,7 @@ class _IntroViewsFlutterState extends State<IntroViewsFlutter>
     return Scaffold(
       //Stack is used to place components over one another.
       resizeToAvoidBottomPadding: false,
+      color: this.background,
       body: Stack(
         children: <Widget>[
           Page(


### PR DESCRIPTION
I wanted to put a full-screen background image BELOW the Intro Views.
I had to make the Scaffold widget transparent for the background to be visible.
This is configurable now. README updated as well.