### PR TITLE
Allow title TextStyle and body TextStyle to be changed individually

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ You should then run `flutter packages get` in your terminal so as to get the pac
           width: 285.0,
           alignment: Alignment.center,
         ),
-        textStyle: TextStyle(fontFamily: 'MyFont', color: Colors.white),
+        titleTextStyle: TextStyle(fontFamily: 'MyFont', color: Colors.white),
+	bodyTextStyle: TextStyle(fontFamily: 'MyFont', color: Colors.white),
       );
   ```
 
@@ -138,7 +139,8 @@ You should then run `flutter packages get` in your terminal so as to get the pac
 | iconImageAssetPath    | String         | Set the icon image asset path that would be displayed in page bubble. |                                              Null                                               |
 | iconColor             | Color          | Set the page bubble icon color.                                       |                                              Null                                               |
 | bubbleBackgroundColor | Color          | Set the page bubble background color.                                 |                                          Colors.white / Color(0x88FFFFFF)                                           |
-| textStyle             | TextStyle      | Set TextStyle for both title and body                                 | title: `color: Colors.white , fontSize: 50.0` <br> body: `color: Colors.white , fontSize: 24.0` |
+| titleTextStyle             | TextStyle      | Set TextStyle for title                                 | title: `color: Colors.white , fontSize: 50.0` <br> body: `color: Colors.white , fontSize: 24.0` |
+| bodyTextStyle             | TextStyle      | Set TextStyle for body                                 | title: `color: Colors.white , fontSize: 50.0` <br> body: `color: Colors.white , fontSize: 24.0` |
 | bubble                | Widget         | Set a custom widget for the inner bubble                              |                                              null                                               |
 
 ### IntroViewFlutter Class

--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ You should then run `flutter packages get` in your terminal so as to get the pac
 | iconImageAssetPath    | String         | Set the icon image asset path that would be displayed in page bubble. |                                              Null                                               |
 | iconColor             | Color          | Set the page bubble icon color.                                       |                                              Null                                               |
 | bubbleBackgroundColor | Color          | Set the page bubble background color.                                 |                                          Colors.white / Color(0x88FFFFFF)                                           |
-| titleTextStyle             | TextStyle      | Set TextStyle for title                                 | title: `color: Colors.white , fontSize: 50.0` <br> body: `color: Colors.white , fontSize: 24.0` |
-| bodyTextStyle             | TextStyle      | Set TextStyle for body                                 | title: `color: Colors.white , fontSize: 50.0` <br> body: `color: Colors.white , fontSize: 24.0` |
+| textStyle             | TextStyle      | Set TextStyle for both title and body                                 | title: `color: Colors.white , fontSize: 50.0` <br> body: `color: Colors.white , fontSize: 24.0` |
+| titleTextStyle             | TextStyle      | Set TextStyle for title                                 | `color: Colors.white , fontSize: 50.0` |
+| bodyTextStyle             | TextStyle      | Set TextStyle for body                                 | `color: Colors.white , fontSize: 24.0` |
 | bubble                | Widget         | Set a custom widget for the inner bubble                              |                                              null                                               |
 
 ### IntroViewFlutter Class

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ You should then run `flutter packages get` in your terminal so as to get the pac
           alignment: Alignment.center,
         ),
         titleTextStyle: TextStyle(fontFamily: 'MyFont', color: Colors.white),
-	bodyTextStyle: TextStyle(fontFamily: 'MyFont', color: Colors.white),
+        bodyTextStyle: TextStyle(fontFamily: 'MyFont', color: Colors.white),
       );
   ```
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -20,7 +20,8 @@ class App extends StatelessWidget {
         title: Text(
           'Flights',
         ),
-        textStyle: TextStyle(fontFamily: 'MyFont', color: Colors.white),
+        titleTextStyle: TextStyle(fontFamily: 'MyFont', color: Colors.white),
+        bodyTextStyle: TextStyle(fontFamily: 'MyFont', color: Colors.white),
         mainImage: Image.asset(
           'assets/airplane.png',
           height: 285.0,
@@ -40,7 +41,8 @@ class App extends StatelessWidget {
         width: 285.0,
         alignment: Alignment.center,
       ),
-      textStyle: TextStyle(fontFamily: 'MyFont', color: Colors.white),
+      titleTextStyle: TextStyle(fontFamily: 'MyFont', color: Colors.white),
+      bodyTextStyle: TextStyle(fontFamily: 'MyFont', color: Colors.white),
     ),
     PageViewModel(
       pageColor: const Color(0xFF607D8B),
@@ -55,7 +57,8 @@ class App extends StatelessWidget {
         width: 285.0,
         alignment: Alignment.center,
       ),
-      textStyle: TextStyle(fontFamily: 'MyFont', color: Colors.white),
+      titleTextStyle: TextStyle(fontFamily: 'MyFont', color: Colors.white),
+      bodyTextStyle: TextStyle(fontFamily: 'MyFont', color: Colors.white),
     ),
   ];
 

--- a/lib/Animation_Gesture/animated_page_dragger.dart
+++ b/lib/Animation_Gesture/animated_page_dragger.dart
@@ -74,6 +74,8 @@ class AnimatedPageDragger {
     completionAnimationController.forward(from: 0.0);
   }
 
+  AnimationStatus get animationStatus => completionAnimationController.status;
+
   //This method is used to dispose animation controller
   void dispose() {
     completionAnimationController.dispose();

--- a/lib/Models/page_view_model.dart
+++ b/lib/Models/page_view_model.dart
@@ -61,11 +61,11 @@ class PageViewModel {
       this.titleTextStyle,
       this.bodyTextStyle});
 
-  TextStyle get titleTextStyle {
-    return TextStyle(color: Colors.white, fontSize: 50.0).merge(this.titleTextStyle);
+  TextStyle get mergedTitleTextStyle {
+    return TextStyle(color: Colors.white, fontSize: 50.0).merge(this.mergedTitleTextStyle);
   }
 
-  TextStyle get bodyTextStyle {
-    return TextStyle(color: Colors.white, fontSize: 24.0).merge(this.bodyTextStyle);
+  TextStyle get mergedBodyTextStyle {
+    return TextStyle(color: Colors.white, fontSize: 24.0).merge(this.mergedBodyTextStyle);
   }
 }

--- a/lib/Models/page_view_model.dart
+++ b/lib/Models/page_view_model.dart
@@ -31,6 +31,9 @@ class PageViewModel {
   /// @Default Textstyle `color: Colors.white, fontSize: 24.0`
   final Widget body;
 
+  /// set default TextStyle for title and body
+  final TextStyle textStyle;
+
   /// set default TextStyle for title
   final TextStyle titleTextStyle;
 
@@ -58,16 +61,19 @@ class PageViewModel {
       @required this.body,
       @required this.mainImage,
       this.bubble,
+      this.textStyle,
       this.titleTextStyle,
       this.bodyTextStyle});
 
   TextStyle get mergedTitleTextStyle {
     return TextStyle(color: Colors.white, fontSize: 50.0)
-        .merge(this.mergedTitleTextStyle);
+        .merge(this.textStyle)
+        .merge(this.titleTextStyle);
   }
 
   TextStyle get mergedBodyTextStyle {
     return TextStyle(color: Colors.white, fontSize: 24.0)
-        .merge(this.mergedBodyTextStyle);
+        .merge(this.textStyle)
+        .merge(this.bodyTextStyle);
   }
 }

--- a/lib/Models/page_view_model.dart
+++ b/lib/Models/page_view_model.dart
@@ -31,8 +31,11 @@ class PageViewModel {
   /// @Default Textstyle `color: Colors.white, fontSize: 24.0`
   final Widget body;
 
-  /// set default TextStyle for both title and body
-  final TextStyle textStyle;
+  /// set default TextStyle for title
+  final TextStyle titleTextStyle;
+  
+  /// set default TextStyle for body
+  final TextStyle bodyTextStyle;
 
   /// Image Widget
   ///
@@ -55,13 +58,14 @@ class PageViewModel {
       @required this.body,
       @required this.mainImage,
       this.bubble,
-      this.textStyle});
+      this.titleTextStyle,
+      this.bodyTextStyle});
 
   TextStyle get titleTextStyle {
-    return TextStyle(color: Colors.white, fontSize: 50.0).merge(this.textStyle);
+    return TextStyle(color: Colors.white, fontSize: 50.0).merge(this.titleTextStyle);
   }
 
   TextStyle get bodyTextStyle {
-    return TextStyle(color: Colors.white, fontSize: 24.0).merge(this.textStyle);
+    return TextStyle(color: Colors.white, fontSize: 24.0).merge(this.bodyTextStyle);
   }
 }

--- a/lib/Models/page_view_model.dart
+++ b/lib/Models/page_view_model.dart
@@ -33,7 +33,7 @@ class PageViewModel {
 
   /// set default TextStyle for title
   final TextStyle titleTextStyle;
-  
+
   /// set default TextStyle for body
   final TextStyle bodyTextStyle;
 
@@ -62,10 +62,12 @@ class PageViewModel {
       this.bodyTextStyle});
 
   TextStyle get mergedTitleTextStyle {
-    return TextStyle(color: Colors.white, fontSize: 50.0).merge(this.mergedTitleTextStyle);
+    return TextStyle(color: Colors.white, fontSize: 50.0)
+        .merge(this.mergedTitleTextStyle);
   }
 
   TextStyle get mergedBodyTextStyle {
-    return TextStyle(color: Colors.white, fontSize: 24.0).merge(this.mergedBodyTextStyle);
+    return TextStyle(color: Colors.white, fontSize: 24.0)
+        .merge(this.mergedBodyTextStyle);
   }
 }

--- a/lib/UI/page.dart
+++ b/lib/UI/page.dart
@@ -128,7 +128,7 @@ class _BodyPageTransform extends StatelessWidget {
           right: 10.0,
         ),
         child: DefaultTextStyle.merge(
-          style: pageViewModel.bodyTextStyle,
+          style: pageViewModel.mergedBodyTextStyle,
           textAlign: TextAlign.center,
           child: pageViewModel.body,
         ),
@@ -194,7 +194,7 @@ class _TitlePageTransform extends StatelessWidget {
           right: 10.0,
         ),
         child: DefaultTextStyle.merge(
-          style: pageViewModel.titleTextStyle,
+          style: pageViewModel.mergedTitleTextStyle,
           child: pageViewModel.title,
         ),
       ), //Padding

--- a/lib/intro_views_flutter.dart
+++ b/lib/intro_views_flutter.dart
@@ -336,20 +336,21 @@ class _IntroViewsFlutterState extends State<IntroViewsFlutter>
     ); //Scaffold
   }
 
-	  void _animateToPage(SlideDirection slideDirection) {
+  void _animateToPage(SlideDirection slideDirection) {
     if (slideDirection == SlideDirection.rightToLeft &&
         widget.pages.length > activePageIndex) {
       nextPageIndex = activePageIndex + 1;
-    }else if (slideDirection == SlideDirection.leftToRight &&
-        activePageIndex -1 >= 0) {
+    } else if (slideDirection == SlideDirection.leftToRight &&
+        activePageIndex - 1 >= 0) {
       nextPageIndex = activePageIndex - 1;
     }
 
-     if (animatedPageDragger?.animationStatus == AnimationStatus.forward) {
+    if (animatedPageDragger?.animationStatus == AnimationStatus.forward) {
       if (widget.pages.length - 1 > nextPageIndex &&
           slideDirection == SlideDirection.rightToLeft) {
         nextPageIndex++;
-      }else if (nextPageIndex > 0 && slideDirection == SlideDirection.leftToRight){
+      } else if (nextPageIndex > 0 &&
+          slideDirection == SlideDirection.leftToRight) {
         nextPageIndex--;
       }
     } else {

--- a/lib/intro_views_flutter.dart
+++ b/lib/intro_views_flutter.dart
@@ -287,27 +287,35 @@ class _IntroViewsFlutterState extends State<IntroViewsFlutter>
             showBackButton: widget.showBackButton,
             onPressedNextButton: () {
               //method executed on pressing next button
-              setState(() {
-                activePageIndex = activePageIndex + 1;
-                nextPageIndex = nextPageIndex + 1;
-                // after next pressed invoke function
-                // this can be used for analytics/page transition
-                if (widget.onTapNextButton != null) {
-                  widget.onTapNextButton();
-                }
-              });
+              // setState(() {
+              //   activePageIndex = activePageIndex + 1;
+              //   nextPageIndex = nextPageIndex + 1;
+              //   // after next pressed invoke function
+              //   // this can be used for analytics/page transition
+              //   if (widget.onTapNextButton != null) {
+              //     widget.onTapNextButton();
+              //   }
+              // });
+              _animateToPage(SlideDirection.rightToLeft);
+              if (widget.onTapNextButton != null) {
+                widget.onTapNextButton();
+              }
             },
             onPressedBackButton: () {
-              //method executed on pressing back button
-              setState(() {
-                activePageIndex = activePageIndex - 1;
-                nextPageIndex = nextPageIndex - 1;
-                // after next pressed invoke function
-                // this can be used for analytics/page transition
-                if (widget.onTapBackButton != null) {
-                  widget.onTapBackButton();
-                }
-              });
+              // //method executed on pressing back button
+              // setState(() {
+              //   activePageIndex = activePageIndex - 1;
+              //   nextPageIndex = nextPageIndex - 1;
+              //   // after next pressed invoke function
+              //   // this can be used for analytics/page transition
+              //   if (widget.onTapBackButton != null) {
+              //     widget.onTapBackButton();
+              //   }
+              // });
+              _animateToPage(SlideDirection.leftToRight);
+              if (widget.onTapBackButton != null) {
+                widget.onTapBackButton();
+              }
             },
             nextText: widget.nextText,
             doneText: widget.doneText,
@@ -326,5 +334,33 @@ class _IntroViewsFlutterState extends State<IntroViewsFlutter>
         ], //Widget
       ), //Stack
     ); //Scaffold
+  }
+
+	  void _animateToPage(SlideDirection slideDirection) {
+    if (slideDirection == SlideDirection.rightToLeft &&
+        widget.pages.length > activePageIndex) {
+      nextPageIndex = activePageIndex + 1;
+    }else if (slideDirection == SlideDirection.leftToRight &&
+        activePageIndex -1 >= 0) {
+      nextPageIndex = activePageIndex - 1;
+    }
+
+     if (animatedPageDragger?.animationStatus == AnimationStatus.forward) {
+      if (widget.pages.length - 1 > nextPageIndex &&
+          slideDirection == SlideDirection.rightToLeft) {
+        nextPageIndex++;
+      }else if (nextPageIndex > 0 && slideDirection == SlideDirection.leftToRight){
+        nextPageIndex--;
+      }
+    } else {
+      animatedPageDragger = AnimatedPageDragger(
+        slideDirection: slideDirection,
+        transitionGoal: TransitionGoal.open,
+        slidePercent: slidePercent,
+        slideUpdateStream: slideUpdateStream,
+        vsync: this,
+      );
+      animatedPageDragger.run();
+    }
   }
 }


### PR DESCRIPTION
This adds two new properties to `PageViewModel`, `titleTextStyle` and `bodyTextStyle`, allowing them to be configured separately.
This keeps the `textStyle` property as well so the API remains compatible with old versions.
Have updated the README and example too.
Thanks for the amazing library btw, really loving using it!
Let me know of any additional steps that need to be done to take this forward.