### PR TITLE
Add test case for portrait orientation.

### DIFF
--- a/lib/UI/page.dart
+++ b/lib/UI/page.dart
@@ -41,6 +41,7 @@ class Page extends StatelessWidget {
   /// when device is Portrait place title, image and body in a column
   Widget _buildPortraitPage() {
     return new Column(
+      key: Key("Portrait Page"),
       mainAxisAlignment: columnMainAxisAlignment,
       mainAxisSize: MainAxisSize.max,
       children: <Widget>[

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -9,6 +9,9 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../example/lib/main.dart';
 
+const double PORTRAIT_WIDTH = 1800.0;
+const double PORTRAIT_HEIGHT = 2400.0;
+
 void main() {
   testWidgets('Skip Pressed smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
@@ -117,5 +120,16 @@ void main() {
     expect(find.text('DONE'), findsNothing);
     expect(find.text('SKIP'), findsOneWidget);
     expect(find.text('NEXT'), findsOneWidget);
+  });
+
+  testWidgets('should open app in portrait mode', (WidgetTester tester) async {
+    final TestWidgetsFlutterBinding binding =
+        TestWidgetsFlutterBinding.ensureInitialized();
+    binding.window.physicalSizeTestValue =
+        (Size(PORTRAIT_WIDTH, PORTRAIT_HEIGHT));
+    // Build our app and trigger a frame in portrait mode.
+    await tester.pumpWidget(new App());
+
+    expect(find.byKey(Key("Portrait Page")), findsWidgets);
   });
 }


### PR DESCRIPTION
Added a test case for opening the app in Portrait Mode,
which, in turn, increases the `codecov` report by 4%

**(Flutter runs the test in landscape mode by default)**