### PR TITLE
refactor(example): dispose the previous route of the navigator on tap Done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.1
+* Updated app example. Thanks @zognotadog
+
 ## 3.1.0
 * Added new `pageBackground` property to the `PageViewModel`, which sets a widget as a
 background of the whole page (`pageColor` has priority over this). Thanks @ride4sun

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     <img src="https://img.shields.io/badge/Platform-Flutter-yellow.svg"
       alt="Platform" />
   </a>
-  <a href="https://pub.dartlang.org/packages/intro_views_flutter">
+  <a href="https://pub.dev/packages/intro_views_flutter">
     <img src="https://img.shields.io/pub/v/intro_views_flutter.svg"
       alt="Pub Package" />
   </a>
@@ -65,7 +65,7 @@ You should ensure that you add the `intro_views_flutter` as a dependency in your
 
 ```yaml
 dependencies:
-  intro_views_flutter: '^3.1.0'
+  intro_views_flutter: '^3.1.1'
 ```
 
 You can also reference the git repository directly if you want:
@@ -138,9 +138,9 @@ You should then run `flutter packages get` in your terminal so as to get the pac
 | :-------------------- | :------------- | :-------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------: |
 | pageColor             | Color?          | Set color of the page.                                                |                                              Null                                               |
 | pageBackground        | Widget         | Set a widget as a background of the whole page (pageColor has priority)            |                                              Null                                               |
-| mainImage             | Image / Widget | Set the main image of the page. If null, then the widget is omitted. |                                              Null                                               |
-| title                 | Text / Widget  | Set the title text of the page. If null, then the widget is omitted.                                       |                                              Null                                               |
-| body                  | Text / Widget  | Set the body text of the page. If null, then the widget is omitted.                                        |                                              Null                                               |
+| mainImage             | Image / Widget | Set the main image of the page. If null, then the widget is omitted. |                                              -                                               |
+| title                 | Text / Widget  | Set the title text of the page. If null, then the widget is omitted.                                       |                                              -                                               |
+| body                  | Text / Widget  | Set the body text of the page. If null, then the widget is omitted.                                        |                                              -                                               |
 | iconImageAssetPath    | String?         | Set the icon image asset path that would be displayed in page bubble. |                                              Null                                               |
 | iconColor             | Color?          | Set the page bubble icon color.                                       |                                              Null                                               |
 | bubbleBackgroundColor | Color          | Set the page bubble background color.                                 |                                          Colors.white / Color(0x88FFFFFF)                                           |

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -91,7 +91,7 @@ class App extends StatelessWidget {
           showNextButton: true,
           showBackButton: true,
           onTapDoneButton: () {
-            //User Navigator.push if you want the user to be able to slide across and back to the intro views
+            // Use Navigator.push if you want the user to be able to slide across and back to the Intro Views.
             Navigator.pushReplacement(
               context,
               MaterialPageRoute(builder: (_) => HomePage()),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -91,7 +91,8 @@ class App extends StatelessWidget {
           showNextButton: true,
           showBackButton: true,
           onTapDoneButton: () {
-            Navigator.push(
+            //User Navigator.push if you want the user to be able to slide across and back to the intro views
+            Navigator.pushReplacement(
               context,
               MaterialPageRoute(builder: (_) => HomePage()),
             );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: intro_views_flutter
 description: A Flutter package for simple material design app intro screens with some cool animations.
-version: 3.1.0
+version: 3.1.1
 homepage: https://github.com/aagarwal1012/IntroViews-Flutter
 
 environment:


### PR DESCRIPTION
Stops users from being able to slide across the screen (from the left edge) to go back to intro views from the HomePage.

May be worth mentioning in the documentation or have commented it in the example.