### PR TITLE
ci: run Firebase preview workflow only on the upstream repo branches

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   preview:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Runs Firebase preview CI workflow only on the upstream repository branches so we don't get failing checks, which might be confusing.

Test PR from my forked repo #100.