### PR TITLE
Feat : Add timed auto-sliding feature for intro pages

### DIFF
--- a/lib/src/animation_gesture/animated_page_dragger.dart
+++ b/lib/src/animation_gesture/animated_page_dragger.dart
@@ -15,6 +15,7 @@ class AnimatedPageDragger {
     required double slidePercent,
     required StreamController<SlideUpdate> slideUpdateStream,
     required TickerProvider vsync,
+    this.autoSlideDuration = const Duration(seconds: 3),
   }) {
     final startSlidePercent = slidePercent;
     double endSlidePercent;
@@ -56,6 +57,11 @@ class AnimatedPageDragger {
           // Adding to slide update stream
           slideUpdateStream.add(SlideUpdate(
               slideDirection, slidePercent, UpdateType.doneAnimating));
+
+          // Start auto-slide timer after animation completes
+          if (_autoSlideEnabled) {
+            _startAutoSlideTimer();
+          }
         }
       });
   }
@@ -68,13 +74,40 @@ class AnimatedPageDragger {
   /// Animation controller.
   late AnimationController completionAnimationController;
 
+  final Duration autoSlideDuration;
+
+  // Add new fields for auto-slide functionality
+  Timer? _autoSlideTimer;
+  bool _autoSlideEnabled = false;
+
   /// This method is used to run animation controller.
   void run() {
     completionAnimationController.forward(from: 0.0);
   }
 
+  // Add new methods for auto-slide control
+  void startAutoSlide() {
+    _autoSlideEnabled = true;
+    _startAutoSlideTimer();
+  }
+
+  void stopAutoSlide() {
+    _autoSlideEnabled = false;
+    _autoSlideTimer?.cancel();
+  }
+
+  void _startAutoSlideTimer() {
+    _autoSlideTimer?.cancel();
+    _autoSlideTimer = Timer(autoSlideDuration, () {
+      if (_autoSlideEnabled) {
+        run();
+      }
+    });
+  }
+
   /// This method is used to dispose animation controller.
   void dispose() {
+    _autoSlideTimer?.cancel();
     completionAnimationController.dispose();
   }
 }

--- a/lib/src/controllers/auto_slide_controller.dart
+++ b/lib/src/controllers/auto_slide_controller.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class AutoSlideController extends ChangeNotifier {
+  bool _isAutoSliding = false;
+  Duration _slideDuration;
+
+  AutoSlideController({Duration slideDuration = const Duration(seconds: 3)})
+      : _slideDuration = slideDuration;
+
+  bool get isAutoSliding => _isAutoSliding;
+  Duration get slideDuration => _slideDuration;
+
+  void startAutoSlide() {
+    _isAutoSliding = true;
+    notifyListeners();
+  }
+
+  void stopAutoSlide() {
+    _isAutoSliding = false;
+    notifyListeners();
+  }
+
+  void setSlideDuration(Duration duration) {
+    _slideDuration = duration;
+    notifyListeners();
+  }
+
+  void toggleAutoSlide() {
+    _isAutoSliding = !_isAutoSliding;
+    notifyListeners();
+  }
+}


### PR DESCRIPTION
This pull request introduces an auto-slide feature to the `AnimatedPageDragger` class and adds a new `AutoSlideController` class to manage auto-slide settings. The changes primarily focus on enabling, controlling, and managing the auto-slide functionality.

Enhancements to `AnimatedPageDragger`:

* Added a new `autoSlideDuration` parameter to the constructor with a default value of 3 seconds.
* Introduced logic to start an auto-slide timer after animation completes, if auto-slide is enabled.
* Added new fields `_autoSlideTimer` and `_autoSlideEnabled` to manage the auto-slide state.
* Implemented methods `startAutoSlide`, `stopAutoSlide`, and `_startAutoSlideTimer` to control the auto-slide functionality.
* Ensured the auto-slide timer is canceled when the `AnimatedPageDragger` is disposed of.

Introduction of `AutoSlideController`:

* Created a new `AutoSlideController` class to manage the auto-slide state and duration, including methods to start, stop, and toggle auto-slide, and set the slide duration.


Taking this [Request](https://github.com/aagarwal1012/IntroViews-Flutter/issues/75) into consideration 